### PR TITLE
fixed double event bug

### DIFF
--- a/frontend/src/store/events.js
+++ b/frontend/src/store/events.js
@@ -190,7 +190,7 @@ function eventsReducer(state = {}, action) {
 
         case CREATE_EVENT:
             newState = {...state};
-            newState[action.event.groupId] = action.event;
+            newState[action.event.id] = action.event;
             return newState;
 
         case DELETE_EVENTS:


### PR DESCRIPTION
CREATE-EVENTS in the events store reducer was spreading the new event into the groupId rather than the event.id